### PR TITLE
fix refresh metrics on new submission

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -31,7 +31,7 @@ export default function Main() {
         if (e.key === 'Enter') {
             e.preventDefault();
 
-            // resetMetrics()
+            resetMetrics()
             
             const newVal = parseInt(e.target.value)
             setHomesRemain(newVal)
@@ -42,7 +42,7 @@ export default function Main() {
 
     const resetMetrics = () => {
 
-        // clearInterval(intervalId)
+        clearInterval(intervalId)
 
         calorieCount = 0
         setHomesRemain(0)


### PR DESCRIPTION
Hi Rob
I was testing the dashboard.

If a simulation was running and Santa pressed Refresh before Stop, the timer kept running. So I added clearInterval to reset btn.

And if a simulation was running and Santa submitted a new number and then pressed Enter - without pressing Stop or Refresh - the target would change, but the rest of the metrics wouldn't. As in, the time, houses with milk/cookies etc all stayed from the last simulation. And it ran without pressing start. So I added resetMetrics into the handleChange.

(I forgot to do a branch and pull request first time. I put it straight in master. So I removed it. That's why when you compare below you'll see the two lines were in there and commented out.)

A bug still remains with the FF button though. FF can start the simulation without pressing Start first. Starts with one click too, not two.

Ta
Chris